### PR TITLE
Fixed typo in _construct_AS_REQ (lib/roaster.py)

### DIFF
--- a/ritm/lib/roaster.py
+++ b/ritm/lib/roaster.py
@@ -128,7 +128,7 @@ class Roaster:
                                     int(constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value),)
                 seq_set_iter(reqBody, 'etype', supportedCiphers)
                 message = encoder.encode(asReq)
-                r = sendReceive(message, self.__realm, self.__kdcIP)
+                r = sendReceive(message, self.__realm, self.__dc_ip)
             elif e.getErrorCode() == constants.ErrorCodes.KDC_ERR_S_PRINCIPAL_UNKNOWN.value:
                 logger.debug(f'Received [red bold]ERR_S_PRINCIPAL_UKNOWN[/] for SPN [blue bold]{username}[/]', extra=OBJ_EXTRA_FMT)
                 return False


### PR DESCRIPTION
Fixed a typo that causes ritm to break when entering into Except block if RC4 is not supported.
Changed self.__kdcIP on L#131 to self.__dc_ip to match the convention